### PR TITLE
Adding parca for system level profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ This will create 1 to 10000 tags of images specified in the load repo which will
 
 ### **Run Phase**
 ### **Usage on openshift platform**
-Deploy `assets/clair-config.yaml` on to your openshift cluster.
+#### **Sample Clair App** : Deploy `assets/clair-setup.yaml` on to your openshift cluster for a sample clair app or else have your own clair app up and running.  
+Next in order to trigger the tests, deploy `assets/clair-config.yaml` on to your openshift cluster.
 ### **Envs**
 * `CLAIR_TEST_HOST` - String indicating clair host to perform testing.
 * `CLAIR_TEST_CONTAINERS` - String with comma separated list of conatiner images.
@@ -116,3 +117,8 @@ Gets the list of manifests from the test repo(created during load phase) which i
 clair-load-test -D report --hitsize=25 --layers=5 --concurrency=10 --delete=true --host=http://example-registry-clair-app-quay-enterprise.apps.vchalla-clair-test.perfscale.devcluster.openshift.com --psk=RUZMTEVxMFI2QmVTRnhhNG5VUTF0ZVJZb1hLeTYwY20= --testrepoprefix="quay.io/vchalla/clair-load-test:mysql_8.0.25" --eshost="https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com" --esport="443" --esindex="clair-test-index"
 ```
 > **NOTE**: Both `--containers` and `--testrepoprefix` options are mutually exclusive.
+
+## **Profiling**
+### **System Level Profiling**
+Inorder to perform system level profiling we use [parca](https://www.parca.dev/docs/overview). To install parca onto your cluster, deploy `assets/parca-server.yaml` and `assets/parca-agent.yaml` in sequence. Now wait until the pods are up and running in the `parca` namespace. For other installation method please refer [this](https://www.parca.dev/docs/quickstart).   
+Once parca is ready, we should be able to logon to the parca route in the `parca` namespace and view the system level profiling data.

--- a/assets/clair-config.yaml
+++ b/assets/clair-config.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: clair-perf-test-serviceaccount
+  namespace: clair-test
 rules:
 - apiGroups: ["extensions", "apps", "batch", "security.openshift.io", "policy"]
   resources: ["deployments", "jobs", "pods", "services", "jobs/status", "podsecuritypolicies", "securitycontextconstraints"]
@@ -12,6 +13,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: clair-perf-test-role
+  namespace: clair-test
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -24,6 +26,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: clair-perf-test-orchestrator
+  namespace: clair-test
   labels:
     clair-perf-test-component: orchestrator
 spec:

--- a/assets/clair-setup.yaml
+++ b/assets/clair-setup.yaml
@@ -2,7 +2,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: quay-enterprise-serviceaccount
+  name: clair-serviceaccount
+  namespace: clair-namespace
 rules:
 - apiGroups:
   - ""
@@ -34,11 +35,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: quay-enterprise-secret-writer
+  name: clair-secret-writer
+  namespace: clair-namespace
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: quay-enterprise-serviceaccount
+  name: clair-serviceaccount
 subjects:
 - kind: ServiceAccount
   name: default
@@ -47,6 +49,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: postgres-clair-storage
+  namespace: clair-namespace
 spec:
   accessModes:
   - ReadWriteOnce
@@ -60,6 +63,7 @@ metadata:
   labels:
     app: postgres-clair
   name: postgres-clair
+  namespace: clair-namespace
 spec:
   replicas: 1
   selector:
@@ -105,6 +109,7 @@ metadata:
   labels:
     app: postgres-clair
   name: postgres-clair
+  namespace: clair-namespace
 spec:
   ports:
   - name: postgres
@@ -119,6 +124,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: clair-configmap
+  namespace: clair-namespace
 data:
   config.yaml: |
     introspection_addr: ""
@@ -166,6 +172,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: clair-deployment
+  namespace: clair-namespace
 spec:
   selector:
     matchLabels:
@@ -227,6 +234,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: clair-service
+  namespace: clair-namespace
 spec:
   selector:
     app: clair
@@ -245,6 +253,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: clair-route
+  namespace: clair-namespace
 spec:
   to:
     kind: Service
@@ -257,6 +266,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: clair-service-monitor
+  namespace: clair-namespace
   labels:
     app: clair
 spec:
@@ -272,6 +282,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: clair-deployment
+  namespace: clair-namespace
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/assets/parca-agent.yaml
+++ b/assets/parca-agent.yaml
@@ -1,0 +1,240 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: parca
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca-agent
+    app.kubernetes.io/name: parca-agent
+    app.kubernetes.io/version: v0.19.0
+  name: parca-agent
+  namespace: parca
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca-agent
+    app.kubernetes.io/name: parca-agent
+    app.kubernetes.io/version: v0.19.0
+  name: parca-agent
+  namespace: parca
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: parca-agent
+subjects:
+- kind: ServiceAccount
+  name: parca-agent
+  namespace: parca
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca-agent
+    app.kubernetes.io/name: parca-agent
+    app.kubernetes.io/version: v0.19.0
+  name: parca-agent
+  namespace: parca
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: observability
+      app.kubernetes.io/instance: parca-agent
+      app.kubernetes.io/name: parca-agent
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: observability
+        app.kubernetes.io/instance: parca-agent
+        app.kubernetes.io/name: parca-agent
+        app.kubernetes.io/version: v0.19.0
+    spec:
+      containers:
+      - args:
+        - /bin/parca-agent
+        - --http-address=:7071
+        - --log-level=info
+        - --node=$(NODE_NAME)
+        - --remote-store-address=parca.parca.svc.cluster.local:7070
+        - --remote-store-insecure
+        - --remote-store-insecure-skip-verify
+        - --debuginfo-strip
+        - --debuginfo-temp-dir=/tmp
+        - --debuginfo-upload-cache-duration=5m
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: ghcr.io/parca-dev/parca-agent:v0.19.0
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: http
+        name: parca-agent
+        ports:
+        - containerPort: 7071
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - SYS_ADMIN
+          privileged: true
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        - mountPath: /run
+          name: run
+        - mountPath: /boot
+          name: boot
+          readOnly: true
+        - mountPath: /lib/modules
+          name: modules
+        - mountPath: /sys/kernel/debug
+          name: debugfs
+        - mountPath: /sys/fs/cgroup
+          name: cgroup
+        - mountPath: /sys/fs/bpf
+          name: bpffs
+        - mountPath: /var/run/dbus/system_bus_socket
+          name: dbus-system
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: parca-agent
+      tolerations:
+      - operator: Exists
+      volumes:
+      - emptyDir: {}
+        name: tmp
+      - hostPath:
+          path: /run
+        name: run
+      - hostPath:
+          path: /boot
+        name: boot
+      - hostPath:
+          path: /sys/fs/cgroup
+        name: cgroup
+      - hostPath:
+          path: /lib/modules
+        name: modules
+      - hostPath:
+          path: /sys/fs/bpf
+        name: bpffs
+      - hostPath:
+          path: /sys/kernel/debug
+        name: debugfs
+      - hostPath:
+          path: /var/run/dbus/system_bus_socket
+        name: dbus-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: parca-agent-scc
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: parca-agent-scc
+  namespace: parca
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: parca-agent-scc
+subjects:
+- kind: ServiceAccount
+  name: parca-agent
+  namespace: parca
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca-agent
+    app.kubernetes.io/name: parca-agent
+    app.kubernetes.io/version: v0.19.0
+  name: parca-agent
+  namespace: parca
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - parca-agent
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca-agent
+    app.kubernetes.io/name: parca-agent
+    app.kubernetes.io/version: v0.19.0
+  name: parca-agent
+  namespace: parca
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: parca-agent
+subjects:
+- kind: ServiceAccount
+  name: parca-agent
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca-agent
+    app.kubernetes.io/name: parca-agent
+    app.kubernetes.io/version: v0.19.0
+  name: parca-agent
+  namespace: parca

--- a/assets/parca-server.yaml
+++ b/assets/parca-server.yaml
@@ -1,0 +1,189 @@
+---
+apiVersion: v1
+data:
+  parca.yaml: |-
+    "object_storage":
+      "bucket":
+        "config":
+          "directory": "/var/lib/parca"
+        "type": "FILESYSTEM"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca
+    app.kubernetes.io/name: parca
+    app.kubernetes.io/version: v0.18.0
+  name: parca
+  namespace: parca
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca
+    app.kubernetes.io/name: parca
+    app.kubernetes.io/version: v0.18.0
+  name: parca
+  namespace: parca
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: observability
+      app.kubernetes.io/instance: parca
+      app.kubernetes.io/name: parca
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: observability
+        app.kubernetes.io/instance: parca
+        app.kubernetes.io/name: parca
+        app.kubernetes.io/version: v0.18.0
+    spec:
+      containers:
+      - args:
+        - /parca
+        - --http-address=:7070
+        - --config-path=/etc/parca/parca.yaml
+        - --log-level=info
+        - --cors-allowed-origins=*
+        - --debuginfod-upstream-servers=https://debuginfod.systemtap.org
+        - --debuginfod-http-request-timeout=5m
+        image: ghcr.io/parca-dev/parca:v0.18.0
+        livenessProbe:
+          exec:
+            command:
+            - /grpc_health_probe
+            - -v
+            - -addr=:7070
+          initialDelaySeconds: 5
+        name: parca
+        ports:
+        - containerPort: 7070
+          name: http
+        readinessProbe:
+          exec:
+            command:
+            - /grpc_health_probe
+            - -v
+            - -addr=:7070
+          initialDelaySeconds: 10
+        resources: {}
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/parca
+          name: config
+        - mountPath: /var/lib/parca
+          name: data
+      nodeSelector:
+        kubernetes.io/os: linux
+      securityContext: null
+      serviceAccountName: parca
+      terminationGracePeriodSeconds: 120
+      volumes:
+      - configMap:
+          name: parca
+        name: config
+      - emptyDir: {}
+        name: data
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+  name: parca
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: parca-serviceaccount
+  namespace: parca
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - put
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: parca-secret-writer
+  namespace: parca
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: parca-serviceaccount
+subjects:
+- kind: ServiceAccount
+  name: parca
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca
+    app.kubernetes.io/name: parca
+    app.kubernetes.io/version: v0.18.0
+  name: parca
+  namespace: parca
+spec:
+  ports:
+  - name: http
+    port: 7070
+    targetPort: 7070
+  selector:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca
+    app.kubernetes.io/name: parca
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: parca-route
+  namespace: parca
+spec:
+  to:
+    kind: Service
+    name: parca
+  port:
+    targetPort: 7070
+  wildcardPolicy: None
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/instance: parca
+    app.kubernetes.io/name: parca
+    app.kubernetes.io/version: v0.18.0
+  name: parca
+  namespace: parca


### PR DESCRIPTION
### Description
Added [parca](https://www.parca.dev/docs/overview) tool assets. 

### Testing
Tested deploying on the openshift cluster.
![system-profiling](https://github.com/quay/clair-load-test/assets/28471457/cd37b77c-4724-4383-8ac4-7a487cc91270)
