### PR TITLE
Added application level profiling POC

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,8 @@ Gets the list of manifests from the test repo(created during load phase) which i
 clair-load-test -D report --hitsize=25 --layers=5 --concurrency=10 --delete=true --host=http://example-registry-clair-app-quay-enterprise.apps.vchalla-clair-test.perfscale.devcluster.openshift.com --psk=RUZMTEVxMFI2QmVTRnhhNG5VUTF0ZVJZb1hLeTYwY20= --testrepoprefix="quay.io/vchalla/clair-load-test:mysql_8.0.25" --eshost="https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com" --esport="443" --esindex="clair-test-index"
 ```
 > **NOTE**: Both `--containers` and `--testrepoprefix` options are mutually exclusive.
+
+## **Profiling**
+### **Application Level Profiling**
+Inorder to perform application level profiling we use [pyroscope](https://pyroscope.io/docs/). To install pyroscope onto your cluster, deploy `assets/pyroscope-server.yaml`. Now wait until the pods are up and running in the `pyroscope` namespace. For other installation methods please refer [this](https://pyroscope.io/docs/server-install-macos/).   
+Once pyroscope is ready, we should be able to logon to the pyroscope route in the `pyroscope` namespace and view the application level profiling data using the tags applied as filters. Please refer to this [tutorial](https://github.com/grafana/pyroscope/tree/main/examples/golang-push) and live [demo](https://demo.pyroscope.io/explore?query=rideshare-app-golang.cpu%7B%7D&groupBy=region&groupByValue=All) for more details on integration.

--- a/assets/pyroscope-server.yaml
+++ b/assets/pyroscope-server.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pyroscope
+  namespace: pyroscope
+  labels:
+    app: pyroscope
+spec:
+  containers:
+    - name: pyroscope
+      image: pyroscope/pyroscope
+      env:
+        - name: PYROSCOPE_LOG_LEVEL
+          value: debug
+      ports:
+        - containerPort: 4040
+      command:
+        - /usr/bin/pyroscope
+        - server
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pyroscope
+  namespace: pyroscope
+spec:
+  selector:
+    app: pyroscope
+  ports:
+    - protocol: TCP
+      port: 4040
+      targetPort: 4040
+  type: ClusterIP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: pyroscope
+  namespace: pyroscope
+spec:
+  to:
+    kind: Service
+    name: pyroscope
+  port:
+    targetPort: 4040
+  wildcardPolicy: None


### PR DESCRIPTION
### Description
Added instructions and tutorial information to integrate application profiling. We need to add tags in the clair application source code in order to properly fetch the trace in flame graphs.

### Testing
Integrating tags in this load generator code will not provide much information in the [flame-graphs](http://pyroscope-pyroscope.apps.vchalla-clair-test-8.perfscale.devcluster.openshift.com/?query=clair-load-test.app.cpu%7B%7D&rightQuery=quay.performance-scripts.app.cpu%7B%7D&leftQuery=quay.performance-scripts.app.cpu%7B%7D&from=now-30d) as shown below.
![go_profiling_poc](https://github.com/quay/clair-load-test/assets/28471457/bfcb6684-aaf0-4e5b-99d9-2580398a9f91)
So the suggestion is to add tags in the clair source code and use the scripts in this repo to generate load and monitor the CPU IO time.