### PR TITLE
Suggesting stderr log type for postgres logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ log_lock_waits = on
 log_temp_files = 0
 log_autovacuum_min_duration = 0
 log_error_verbosity = default
-log_destination = 'csvlog'
+log_destination = 'stderr'
 logging_collector = on
 log_rotation_age = 1d
 log_rotation_size = 0
@@ -155,7 +155,7 @@ pg_ctl restart -D /var/lib/postgresql/data
 
 * **Step 4**: Then execute the below command to process those logs and get an html report. For more details on usage of `pgBadger`, refer [here](https://github.com/darold/pgbadger#table-of-contents).
 ```
-pgbadger -j 8 ~/output/postgresql-2023-06-18_141703.csv -o /home/vchalla/output/output.html --format html
+pgbadger -j 8 ~/output/postgresql-2023-06-18_141703.log -o /home/vchalla/output/output.html --format html
 ```
 
 > **NOTE**: It is suggested to disable logs collector once we do the profiling to avoid overhead created by logs files getting accumulating in the DB.


### PR DESCRIPTION
Moving from `csvlog` to `stderr` as pgBadger cannot parallel process logs when it is in `CSV` format. More details [here](https://github.com/darold/pgbadger#:~:text=pgBadger%20can%20also%20be%20used%20in%20a%20central%20place%20to%20parse%20remote%20log%20files%20using%20a%20passwordless%20SSH%20connection.%20This%20mode%20can%20be%20used%20with%20compressed%20files%20and%20in%20the%20multiprocess%20per%20file%20mode%20(%2DJ)%2C%20but%20cannot%20be%20used%20with%20the%20CSV%20log%20format.)