### PR TITLE
removing apt-get command specific to ubuntu

### DIFF
--- a/assets/image_load.sh
+++ b/assets/image_load.sh
@@ -79,7 +79,6 @@ WORKDIR /app$5$i
 RUN echo "#!/bin/sh" > myscript$5$i.sh && echo "echo \"Hello, world!\"" >> myscript$5$i.sh
 FROM $4
 WORKDIR /app$5$i
-RUN apt-get update && apt-get install -y --no-install-recommends tar && rm -rf /var/lib/apt/lists/*
 COPY --from=tarbuilder$5$i my_file$5$i.tar /app$5$i/
 COPY --from=tarbuilder$5$i my_file$5$i.tar /build$5$i/app$5$5$i$i/
 RUN tar -xf /app$5$i/my_file$5$i.tar --overwrite


### PR DESCRIPTION
###Description
Removing `apt-get` command in image_load.sh script as it is specific to ubuntu and stopping from building other images.
Example instance: https://redhat-internal.slack.com/archives/C0149E54AH5/p1694161444592799

###Testing
Tested running this command and verified its working with all the default `IMAGES` of different distributions in the script.
```
START=1 END=20 LAYERS=20 LOAD_REPO="quay.io/quay-qetest/clair-load-test" RATE=1 bash image_load.sh
```